### PR TITLE
Dev/apihost

### DIFF
--- a/Services/SimpleGeo.php
+++ b/Services/SimpleGeo.php
@@ -98,12 +98,13 @@ class Services_SimpleGeo
      * @return void
      * @see HTTP_OAuth_Consumer
      */
-    public function __construct($token, $secret, $version = '0.1')
+    public function __construct($token, $secret, $version = '0.1', $host = 'api.simplegeo.com')
     {
         $this->_oauth   = new HTTP_OAuth_Consumer($token, $secret);
         $this->_version = $version;
         $this->_token   = $token;
         $this->_secret  = $secret;
+        $this->_api = "http://{$host}";
     }
 
     /**


### PR DESCRIPTION
we need to be able to override the hostname the requests go to for internal testing purposes; this path adds a constructor argument to specify a host.
